### PR TITLE
Fix Bankdata: DHL requires an specific order

### DIFF
--- a/lib/dhl-intraship/bankdata.rb
+++ b/lib/dhl-intraship/bankdata.rb
@@ -19,8 +19,8 @@ module Dhl
           xml.cis(:bankCode, bank_code) unless bank_code.blank?
           xml.cis(:bankName, bank_name) unless bank_name.blank?
           xml.cis(:iban, iban) unless iban.blank?
-          xml.cis(:bic, bic) unless bic.blank?
           xml.cis(:note, note) unless note.blank?
+          xml.cis(:bic, bic) unless bic.blank?
         end
       end
     end


### PR DESCRIPTION
It looks like DHL has changed something in their Cash On Delivery implementation while enabling BIC and IBAN.
The field `note` MUST be between IBAN and BIC, else you get a weird „Bank details are missing“ error from their server.
This pull request fixes the order of the submitted fields.
