### PR TITLE
bugfix: multipack service is not allowed for EPX

### DIFF
--- a/lib/dhl-intraship/shipment.rb
+++ b/lib/dhl-intraship/shipment.rb
@@ -114,7 +114,7 @@ module Dhl
 
       def add_dhl_paket_multipack_service?
         shipment_items.size > 1 and
-          ([ProductCode::DHL_DOMESTIC_EXPRESS, ProductCode::DHL_PACKAGE].include?(product_code))
+          product_code == ProductCode::DHL_PACKAGE
       end
     end
   end


### PR DESCRIPTION
Multi parcel shipment by DHL Express is standard,
so we only have to add multiple shipment items.
